### PR TITLE
Allow for undefined command param on ensure => absent

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -73,7 +73,7 @@
 #   Default: undef
 #
 define sensu::check(
-  $command,
+  $command             = undef,
   $ensure              = 'present',
   $type                = undef,
   $handlers            = undef,
@@ -95,6 +95,9 @@ define sensu::check(
 
   validate_re($ensure, ['^present$', '^absent$'] )
   validate_bool($standalone)
+  if $ensure == 'present' and !$command {
+    fail("sensu::check{${name}}: a command must be given when ensure is present")
+  }
   if !is_integer($interval) {
     fail("sensu::check{${name}}: interval must be an integer (got: ${interval})")
   }


### PR DESCRIPTION
Before this change, declaring a sensu::check to be absent with no command would fail:

```
  sensu::check {
    'check_system_raid':
      ensure => 'absent';
  }
```
The above would cause:
```
Error: Could not retrieve catalog from remote server:
Error 400 on SERVER:
Evaluation Error:
Error while evaluating a Resource Statement, Sensu::Check[check_system_raid]:
expects a value for parameter 'command' at [..] on node [...]
```

This commit allows for undefined `command` parameter which would be validated only if ensure is present (default), raising a specific error if command is missing.